### PR TITLE
refs wechatpay-apiv3/wechatpay-guzzle-middleware#6, implementation th…

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,40 @@ try {
 }
 ```
 
+### 上传媒体文件
 
+```php
+// 参考上述说明，引入 `MediaUtil` 正常初始化，无额外条件
+use WechatPay\GuzzleMiddleware\Util\MediaUtil;
+// 实例化一个媒体文件流，注意文件后缀名需符合接口要求
+$media = new MediaUtil('/your/file/path/with.extension');
+
+// 正常使用Guzzle发起API请求
+try {
+    $resp = $client->request('POST', 'https://api.mch.weixin.qq.com/v3/[merchant/media/video_upload|marketing/favor/media/image-upload]', [
+        'body'    => $media->getStream(),
+        'headers' => [
+            'Accept'       => 'application/json',
+            'content-type' => $media->getContentType(),
+        ]
+    ]);
+    // POST 语法糖
+    $resp = $client->post('merchant/media/upload', [
+        'body'    => $media->getStream(),
+        'headers' => [
+            'Accept'       => 'application/json',
+            'content-type' => $media->getContentType(),
+        ]
+    ]);
+} catch (Exception $e) {
+    echo $e->getMessage()."\n";
+    if ($e->hasResponse()) {
+        echo $e->getResponse()->getStatusCode().' '.$e->getResponse()->getReasonPhrase()."\n";
+        echo $e->getResponse()->getBody();
+    }
+    return;
+}
+```
 
 ## 定制
 

--- a/src/Util/MediaUtil.php
+++ b/src/Util/MediaUtil.php
@@ -1,0 +1,142 @@
+<?php
+/**
+ * MediaUtil
+ * PHP version 5
+ *
+ * @category Class
+ * @package  WechatPay
+ * @author   WeChatPay Team
+ * @link     https://pay.weixin.qq.com
+ */
+
+namespace WechatPay\GuzzleMiddleware\Util;
+
+use GuzzleHttp\Psr7\UploadedFile;
+use GuzzleHttp\Psr7\MultipartStream;
+use GuzzleHttp\Psr7\FnStream;
+
+/**
+ * Util for Media(image or video) uploading.
+ *
+ * @package  WechatPay
+ * @author   James Zhang(https://github.com/TheNorthMemory)
+ */
+class MediaUtil {
+
+    /**
+     * local file path
+     *
+     * @var string
+     */
+    private $filepath;
+
+    /**
+     * upload meta json
+     *
+     * @var string
+     */
+    private $json;
+
+    /**
+     * upload contents stream
+     *
+     * @var MultipartStream
+     */
+    private $multipart;
+
+
+    /**
+     * multipart stream wrapper
+     *
+     * @var FnStream
+     */
+    private $stream;
+
+    /**
+     * Constructor
+     *
+     * @param string $filepath The media file path,
+     *                         should be one of the
+     *                         images(jpg|bmp|png)
+     *                         or
+     *                         video(avi|wmv|mpeg|mp4|mov|mkv|flv|f4v|m4v|rmvb)
+     */
+    public function __construct($filepath)
+    {
+        $this->filepath = $filepath;
+        $this->composeStream();
+    }
+
+    /**
+     * Compose the GuzzleHttp\Psr7\FnStream
+     */
+    private function composeStream()
+    {
+        $basename = \basename($this->filepath);
+        $uploader = new UploadedFile(
+            $this->filepath,
+            0,
+            UPLOAD_ERR_OK,
+            $basename,
+            \GuzzleHttp\Psr7\mimetype_from_filename($this->filepath)
+        );
+        $stream = $uploader->getStream();
+
+        $json = \GuzzleHttp\json_encode([
+            'filename' => $basename,
+            'sha256'   => \GuzzleHttp\Psr7\hash($stream, 'sha256'),
+        ]);
+        $this->meta = $json;
+
+        $multipart = new MultipartStream([
+            [
+                'name'     => 'meta',
+                'contents' => $json,
+                'headers'  => [
+                    'Content-Type' => 'application/json',
+                ],
+            ],
+            [
+                'name'     => 'file',
+                'filename' => $basename,
+                'contents' => $stream,
+            ],
+        ]);
+        $this->multipart = $multipart;
+
+        $this->stream = FnStream::decorate($multipart, [
+             // for signature
+            '__toString' => function () use ($json) {
+                return $json;
+            },
+             // let the `CURL` to use `CURLOPT_UPLOAD` context
+            'getSize' => function () {
+                return null;
+            },
+        ]);
+    }
+
+    /**
+     * Get the `meta` of the multipart data string
+     */
+    public function getMeta()
+    {
+        return $this->meta;
+    }
+
+    /**
+     * Get the `GuzzleHttp\Psr7\FnStream` context
+     */
+    public function getStream()
+    {
+        return $this->stream;
+    }
+
+    /**
+     * Get the `Content-Type` of the `GuzzleHttp\Psr7\MultipartStream`
+     */
+    public function getContentType()
+    {
+        return 'multipart/form-data; boundary=' . $this->multipart->getBoundary();
+    }
+}


### PR DESCRIPTION
不增加额外调整改动，仅使用 `GuzzleHttp\Psr7\FnStream` 来实现媒体文件上传，mac上已测试

- `/v3/merchant/media/upload`
- `/v3/merchant/media/video_upload`
- `/v3/marketing/favor/media/image-upload`

均达预期效果。

测试环境信息如下:

php -v

```
PHP 7.3.11 (cli) (built: Dec 13 2019 19:21:21) ( NTS )
```

php -i|grep -i openssl

```
openssl
OpenSSL support => enabled
OpenSSL Library Version => LibreSSL 2.8.3
OpenSSL Header Version => LibreSSL 2.8.3
```