### PR TITLE
feat: wechatpay-apiv3/wechatpay-guzzle-middleware#17 敏感信息加解密功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,9 +176,9 @@ try {
 }
 
 // 单例加解密示例如下
-$codec = new SensitiveInfoCrypto($wechatpayCertificate, $merchantPrivateKey);
-$encrypted = $codec('Alice');
-$decrypted = $codec->setStage('decrypt')($encrypted);
+$crypto = new SensitiveInfoCrypto($wechatpayCertificate, $merchantPrivateKey);
+$encrypted = $crypto('Alice');
+$decrypted = $crypto->setStage('decrypt')($encrypted);
 ```
 
 ## 定制

--- a/README.md
+++ b/README.md
@@ -140,10 +140,10 @@ try {
 ### 敏感信息加/解密
 
 ```php
-// 参考上上述说明，引入 `SensitiveInfoCodec`
-use WechatPay\GuzzleMiddleware\Util\SensitiveInfoCodec;
+// 参考上上述说明，引入 `SensitiveInfoCrypto`
+use WechatPay\GuzzleMiddleware\Util\SensitiveInfoCrypto;
 // 上行加密API 多于 下行解密，默认为加密，实例后直接当方法用即可
-$encryptor = new SensitiveInfoCodec(PemUtil::loadCertificate('/downloaded/public.pem'));
+$encryptor = new SensitiveInfoCrypto(PemUtil::loadCertificate('/downloaded/public.pem'));
 
 // 正常使用Guzzle发起API请求
 try {
@@ -152,10 +152,10 @@ try {
         'json' => [
             'business_code' => 'APL_98761234',
             'contact_info'  => [
-                'contact_name'      => $encryptor('窃格瓦拉'),
-                'contact_id_number' => $encryptor('45012119841227000X'),
-                'mobile_phone'      => $encryptor('12345678901'),
-                'contact_email'     => $encryptor('noop@real.world'),
+                'contact_name'      => $encryptor('value of `contact_name`'),
+                'contact_id_number' => $encryptor('value of `contact_id_number'),
+                'mobile_phone'      => $encryptor('value of `mobile_phone`'),
+                'contact_email'     => $encryptor('value of `contact_email`'),
             ],
             //...
         ],
@@ -176,8 +176,8 @@ try {
 }
 
 // 单例加解密示例如下
-$codec = new SensitiveInfoCodec($wechatpayCertificate, $merchantPrivateKey);
-$encrypted = $codec('窃格瓦拉');
+$codec = new SensitiveInfoCrypto($wechatpayCertificate, $merchantPrivateKey);
+$encrypted = $codec('Alice');
 $decrypted = $codec->setStage('decrypt')($encrypted);
 ```
 

--- a/README.md
+++ b/README.md
@@ -160,7 +160,10 @@ try {
             //...
         ],
         'headers' => [
-            'Accept' => 'application/json',
+            // 命令行获取证书序列号
+            // openssl x509 -in /downloaded/public.pem -noout -serial | awk -F= '{print $2}'
+            'Wechatpay-Serial' => 'must be the serial number via the downloaded pem file of `/v3/certificates`',
+            'Accept'           => 'application/json',
         ],
     ]);
 } catch (Exception $e) {

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ try {
 // 参考上上述说明，引入 `SensitiveInfoCodec`
 use WechatPay\GuzzleMiddleware\Util\SensitiveInfoCodec;
 // 上行加密API 多于 下行解密，默认为加密，实例后直接当方法用即可
-$encryptor = new SensitiveInfoCodec(pem::loadCertificate('/downloaded/public.pem'));
+$encryptor = new SensitiveInfoCodec(PemUtil::loadCertificate('/downloaded/public.pem'));
 
 // 正常使用Guzzle发起API请求
 try {

--- a/src/Util/MediaUtil.php
+++ b/src/Util/MediaUtil.php
@@ -19,7 +19,6 @@ use GuzzleHttp\Psr7\FnStream;
  * Util for Media(image or video) uploading.
  *
  * @package  WechatPay
- * @author   James Zhang(https://github.com/TheNorthMemory)
  */
 class MediaUtil {
 

--- a/src/Util/SensitiveInfoCodec.php
+++ b/src/Util/SensitiveInfoCodec.php
@@ -21,8 +21,7 @@ namespace WechatPay\GuzzleMiddleware\Util;
  *
  * // Decrypt usage:
  * $codec = new SensitiveInfoCodec(null, Pem::loadPrivateKey('/merchant/key.pem'));
- * $name = (string) $codec('Bob');
- * $codes->setStage('decrypt')($name);
+ * $decrypted = $codec->setStage('decrypt')('base64 encoding message was given by the payment plat');
  * // That's it simple too!
  *
  * // Working both Encrypt and Decrypt usage:

--- a/src/Util/SensitiveInfoCodec.php
+++ b/src/Util/SensitiveInfoCodec.php
@@ -35,7 +35,6 @@ namespace WechatPay\GuzzleMiddleware\Util;
  * </code>
  *
  * @package  WechatPay
- * @author   James Zhang(https://github.com/TheNorthMemory)
  */
 class SensitiveInfoCodec implements \JsonSerializable {
 

--- a/src/Util/SensitiveInfoCodec.php
+++ b/src/Util/SensitiveInfoCodec.php
@@ -1,0 +1,140 @@
+<?php
+/**
+ * SensitiveInfoCodec
+ * PHP version 7
+ *
+ * @category Class
+ * @package  WechatPay
+ * @author   WeChatPay Team
+ * @link     https://pay.weixin.qq.com
+ */
+namespace WechatPay\GuzzleMiddleware\Util;
+
+/**
+ * Codec for Encrypt/Decrypt the sensitive information by the certificates pair.
+ *
+ * <code>
+ * // Encrypt usage:
+ * $codec = new SensitiveInfoCodec(Pem::loadCertificate('/downloaded/pubcert.pem'));
+ * $json = json_encode(['name' => $codec('Alice')]);
+ * // That's it simple!
+ *
+ * // Decrypt usage:
+ * $codec = new SensitiveInfoCodec(null, Pem::loadPrivateKey('/merchant/key.pem'));
+ * $name = (string) $codec('Bob');
+ * $codes->setStage('decrypt')($name);
+ * // That's it simple too!
+ *
+ * // Working both Encrypt and Decrypt usage:
+ * $codec = new SensitiveInfoCodec(
+ *     Pem::loadCertificate('/merchant/cert.pem'),
+ *     Pem::loadPrivateKey('/merchant/key.pem')
+ * );
+ * $encrypted = $codec('Carol');
+ * $decrypted = $codec->setStage('decrypt')($encrypted);
+ * // Having fun with this!
+ * </code>
+ *
+ * @package  WechatPay
+ * @author   James Zhang(https://github.com/TheNorthMemory)
+ */
+class SensitiveInfoCodec implements \JsonSerializable {
+
+    /**
+     * @var int Equal to OPENSSL_PKCS1_OAEP_PADDING constant,
+     *          to prevent the fault error while the PHP_VERSION < 7.0.
+     */
+    const OPENSSL_PKCS1_OAEP_PADDING = 4;
+
+    /**
+     * @var resource|null $publicCert The offical public certificate,
+     *                                which should be downloaded via `/v3/certificates`
+     */
+    private $publicCert;
+
+    /**
+     * @var resource|null $privateCert The merchant private certificate
+     */
+    private $privateCert;
+
+    /**
+     * @var string $message The encryped or decrypted content
+     */
+    private $message;
+
+    /**
+     * @var string $stage The codec working scenario, default is `encrypt`.
+     *                    Mention here: while toggle the scenario,
+     *                    the next stage is the previous one.
+     */
+    private $stage = 'encrypt';
+
+    /**
+     * Constructor
+     *
+     * @param resource|null $publicCert The offical public certificate resource
+     * @param resource|null $privateCert The merchant private certificate resource
+     */
+    public function __construct($publicCert, $privateCert = null) {
+        $this->publicCert = $publicCert;
+        $this->privateCert = $privateCert;
+    }
+
+    /**
+     * Encrypt the string by the public certificate
+     *
+     * @param string $str The content shall be encrypted
+     *
+     * @return SensitiveInfoCodec
+     */
+    private function encrypt($str) {
+        openssl_public_encrypt($str, $encrypted, $this->publicCert, self::OPENSSL_PKCS1_OAEP_PADDING);
+        $this->message = base64_encode($encrypted);
+
+        return $this;
+    }
+
+    /**
+     * Decrypt the string by the private certificate
+     *
+     * @param string $str The content shall be decrypted
+     *
+     * @return SensitiveInfoCodec
+     */
+    private function decrypt($str) {
+        openssl_private_decrypt(base64_decode($str), $decrypted, $this->privateCert, self::OPENSSL_PKCS1_OAEP_PADDING);
+        $this->message = $decrypted;
+
+        return $this;
+    }
+
+    /**
+     * Specify data which should be
+     *
+     * @return string
+     */
+    public function jsonSerialize() {
+        return $this->message;
+    }
+
+    /**
+     * Toggle the codec instance onto `encrypt` or `decrypt` stage
+     *
+     * @param string $scenario Should be `encrypt` or `decrypt`
+     *
+     * @return SensitiveInfoCodec
+     */
+    public function setStage($scenario) {
+        $this->stage = $scenario;
+
+        return $this;
+    }
+
+    public function __invoke($str) {
+        return (clone $this)->{$this->stage}($str);
+    }
+
+    public function __toString() {
+        return $this->jsonSerialize();
+    }
+}

--- a/src/Util/SensitiveInfoCrypto.php
+++ b/src/Util/SensitiveInfoCrypto.php
@@ -11,23 +11,23 @@
 namespace WechatPay\GuzzleMiddleware\Util;
 
 /**
- * Codec for Encrypt/Decrypt the sensitive information by the certificates pair.
+ * Encrypt/Decrypt the sensitive information by the certificates pair.
  *
  * <code>
  * // Encrypt usage:
  * $codec = new SensitiveInfoCrypto(PemUtil::loadCertificate('/downloaded/pubcert.pem'));
  * $json = json_encode(['name' => $codec('Alice')]);
- * // That's it simple!
+ * // That's simple!
  *
  * // Decrypt usage:
  * $codec = new SensitiveInfoCrypto(null, PemUtil::loadPrivateKey('/merchant/key.pem'));
  * $decrypted = $codec->setStage('decrypt')('base64 encoding message was given by the payment plat');
- * // That's it simple too!
+ * // That's simple too!
  *
- * // Working both Encrypt and Decrypt usage:
+ * // Working both Encrypt and Decrypt usages:
  * $codec = new SensitiveInfoCrypto(
- *     Pem::loadCertificate('/merchant/cert.pem'),
- *     Pem::loadPrivateKey('/merchant/key.pem')
+ *     PemUtil::loadCertificate('/merchant/cert.pem'),
+ *     PemUtil::loadPrivateKey('/merchant/key.pem')
  * );
  * $encrypted = $codec('Carol');
  * $decrypted = $codec->setStage('decrypt')($encrypted);

--- a/src/Util/SensitiveInfoCrypto.php
+++ b/src/Util/SensitiveInfoCrypto.php
@@ -72,6 +72,11 @@ class SensitiveInfoCrypto implements \JsonSerializable {
      * @param resource|null $privateCert The private certificate resource
      */
     public function __construct($publicCert, $privateCert = null) {
+        if (!(is_resource($publicCert) || is_resource($privateCert))) {
+            throw new \InvalidArgumentException(
+                'The `publicCert`, `privateCert` must be available one resource at least'
+            );
+        }
         $this->publicCert = $publicCert;
         $this->privateCert = $privateCert;
     }

--- a/src/Util/SensitiveInfoCrypto.php
+++ b/src/Util/SensitiveInfoCrypto.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * SensitiveInfoCrypto
- * PHP version 7
+ * PHP version 5
  *
  * @category Class
  * @package  WechatPay
@@ -39,19 +39,12 @@ namespace WechatPay\GuzzleMiddleware\Util;
 class SensitiveInfoCrypto implements \JsonSerializable {
 
     /**
-     * @var int Equal to OPENSSL_PKCS1_OAEP_PADDING constant,
-     *          to prevent the fault error while the PHP_VERSION < 7.0.
-     */
-    const OPENSSL_PKCS1_OAEP_PADDING = 4;
-
-    /**
-     * @var resource|null $publicCert The offical public certificate,
-     *                                which should be downloaded via `/v3/certificates`
+     * @var resource|null $publicCert The public certificate
      */
     private $publicCert;
 
     /**
-     * @var resource|null $privateCert The merchant private certificate
+     * @var resource|null $privateCert The private certificate
      */
     private $privateCert;
 
@@ -75,8 +68,8 @@ class SensitiveInfoCrypto implements \JsonSerializable {
     /**
      * Constructor
      *
-     * @param resource|null $publicCert The offical public certificate resource
-     * @param resource|null $privateCert The merchant private certificate resource
+     * @param resource|null $publicCert The public certificate resource
+     * @param resource|null $privateCert The private certificate resource
      */
     public function __construct($publicCert, $privateCert = null) {
         $this->publicCert = $publicCert;
@@ -91,7 +84,7 @@ class SensitiveInfoCrypto implements \JsonSerializable {
      * @return SensitiveInfoCrypto
      */
     private function encrypt($str) {
-        openssl_public_encrypt($str, $encrypted, $this->publicCert, self::OPENSSL_PKCS1_OAEP_PADDING);
+        openssl_public_encrypt($str, $encrypted, $this->publicCert, \OPENSSL_PKCS1_OAEP_PADDING);
         $this->message = base64_encode($encrypted);
 
         return $this;
@@ -105,7 +98,7 @@ class SensitiveInfoCrypto implements \JsonSerializable {
      * @return SensitiveInfoCrypto
      */
     private function decrypt($str) {
-        openssl_private_decrypt(base64_decode($str), $decrypted, $this->privateCert, self::OPENSSL_PKCS1_OAEP_PADDING);
+        openssl_private_decrypt(base64_decode($str), $decrypted, $this->privateCert, \OPENSSL_PKCS1_OAEP_PADDING);
         $this->message = $decrypted;
 
         return $this;


### PR DESCRIPTION
新增「加解密」功能， 测试校准@ PHP 7.3.11 with LibreSSL 2.8.3

- 上行加密@ `/v3/smartguide/guides`
- 下行解密@ `/v3/merchant-service/complaints`

备注：`OPENSSL_PKCS1_OAEP_PADDING` 自PHP7引入，此lib未在`PHP5`系列测试，使用时请注意PHP版本。